### PR TITLE
Add Kubernetes Manifests

### DIFF
--- a/.k8s/deployment.yaml
+++ b/.k8s/deployment.yaml
@@ -24,12 +24,13 @@ spec:
               protocol: TCP
           resources:
             limits:
-              cpu: "750m"
-              memory: "1500m"
+              cpu: "500m"
+              memory: "1G"
           readinessProbe:
             httpGet:
               port: 8080
               path: /actuator/health
+            successThreshold: 3
             failureThreshold: 2
             periodSeconds: 20
             timeoutSeconds: 2
@@ -37,7 +38,6 @@ spec:
             httpGet:
               port: 8080
               path: /actuator/health
-            successThreshold: 3
             failureThreshold: 2
             periodSeconds: 30
             timeoutSeconds: 2

--- a/.k8s/deployment.yaml
+++ b/.k8s/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: af-location
+  labels:
+    app: assignforce
+    service: location
+spec:
+  selector:
+    matchLabels:
+      service: location
+  template:
+    metadata:
+      labels:
+        service: location
+    spec:
+      containers:
+        - name: af-location
+          image: 855430746673.dkr.ecr.us-east-1.amazonaws.com/af-location-service:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              name: loc-http
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "750m"
+              memory: "1500m"
+          readinessProbe:
+            httpGet:
+              port: 8080
+              path: /actuator/health
+            failureThreshold: 2
+            periodSeconds: 20
+            timeoutSeconds: 2
+          livenessProbe:
+            httpGet:
+              port: 8080
+              path: /actuator/health
+            successThreshold: 3
+            failureThreshold: 2
+            periodSeconds: 30
+            timeoutSeconds: 2

--- a/.k8s/service.yaml
+++ b/.k8s/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: af-location-svc
+  labels:
+    app: assignforce
+spec:
+  ports:
+    - port: 10001
+      targetPort: loc-http
+      protocol: TCP
+  selector:
+    service: location

--- a/af-location-service/pom.xml
+++ b/af-location-service/pom.xml
@@ -29,6 +29,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 			<version>2.4.3</version>
 		</dependency>


### PR DESCRIPTION
* Added a `Deployment` for the `af-location-service`
* Added a `Service` of type `ClusterIP` to route traffic from port 10001 to the `Pod`'s port 8080
* Added the `spring-boot-starter-actuator` Maven dependency to enable proper liveness/readiness probes
* *NOTE* the `PodSpec` image tag will be different from `latest` since we are using the Git SHA to tag images at the build step